### PR TITLE
fix(deps): bump concurrent-ruby & faraday to patched versions

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
     coffee-script-source (1.12.2)
     colorator (1.1.0)
     commonmarker (0.23.12)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     csv (3.3.3)
     dnsruby (1.73.0)
@@ -39,11 +39,11 @@ GEM
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
     execjs (2.10.0)
-    faraday (2.14.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.3)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
     ffi (1.17.1)
     ffi (1.17.1-aarch64-linux-gnu)
@@ -225,7 +225,7 @@ GEM
       gemoji (>= 3, < 5)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    json (2.19.5)
+    json (2.20.0)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)


### PR DESCRIPTION
Resolves the 4 open Dependabot alerts in `docs/Gemfile.lock`.

| Gem | From | To | Advisory |
|---|---|---|---|
| concurrent-ruby (high+2 low) | 1.3.6 | 1.3.7 | GHSA-h8w8-99g7-qmvj, -6wx8-w4f5-wwcr, -wv3x-4vxv-whpp |
| faraday (high) | 2.14.2 | 2.14.3 | GHSA-98m9-hrrm-r99r |

Both patched versions fit the existing lock constraints — `github-pages (232)` / `jekyll` unchanged. Incidental sub-dep bumps: `faraday-net_http` 3.4.3→3.4.4, `json` 2.19.5→2.20.0 (not vulnerable).

Transitive build-time deps only; the site is built by GitHub Pages' native build, so no runtime/served-content impact — this just clears the alerts on the committed lockfile.