### PR TITLE
style(blog): show category tags on previews, tidy spacing & nav order

### DIFF
--- a/docs/_includes/category-index.html
+++ b/docs/_includes/category-index.html
@@ -11,5 +11,5 @@
 </div>
 
 {% for post in cat_posts %}
-  {% include post-preview.html post=post show_categories=false %}
+  {% include post-preview.html post=post show_categories=true %}
 {% endfor %}

--- a/docs/_includes/footer_custom.html
+++ b/docs/_includes/footer_custom.html
@@ -1,3 +1,1 @@
-<footer>
-  Copyright &copy; 2022-{{ site.time | date: '%Y' }} LabIMotion.
-</footer>
+Copyright &copy; 2022-{{ site.time | date: '%Y' }} LabIMotion.

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -144,6 +144,7 @@ h1, h2, h3, h4, h5, h6 {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
+  gap: 0.5em;
 }
 
 
@@ -151,8 +152,6 @@ h1, h2, h3, h4, h5, h6 {
 .category-tag {
   display: inline-block;
   padding: 0.2em 1em;
-  margin-right: 0.2em;
-  // margin: 0 0.2em 0.2em 0;  // Added bottom margin for wrapping
   border-radius: 40px;
   border: thin solid var(--category-border-color);
   font-size: 0.8em;
@@ -603,7 +602,7 @@ table {
 
   h3 {
     margin-top: 0.25rem !important;
-    margin-bottom: 0.25rem !important;
+    margin-bottom: 0.375rem !important;
     font-size: 1.3125rem;
     letter-spacing: -0.015em;
     line-height: 1.19;
@@ -616,13 +615,13 @@ table {
 
   p {
     color: var(--apple-text-sec);
-    margin: 0.125rem 0 0.375rem !important;
+    margin: 0.25rem 0 0.375rem !important;
     font-size: 0.9375rem;
     line-height: 1.47;
   }
 
   .post-categories {
-    margin: 0 0 0.125rem !important;
+    margin: 0 0 0.5rem !important;
   }
 
   time {

--- a/docs/blog/archive.md
+++ b/docs/blog/archive.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Archive
-nav_order: 3
+nav_order: 4
 permalink: /blog/archive
 ---
 

--- a/docs/blog/changelog/index.md
+++ b/docs/blog/changelog/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Changelog
-nav_order: 4
+nav_order: 3
 ---
 
 <div class="apple-hero-light" markdown="1">


### PR DESCRIPTION
- Enable category tags on post previews
- Add row gap and tidy .category-tag margins
- Bump post-card heading/paragraph/category spacing
- Swap Changelog/Archive sidebar order
- Simplify footer markup (drop <footer> wrapper)