### PR TITLE
docs(blog): drop Announcements category from feature preview posts

### DIFF
--- a/docs/blog/categories/preview/2026-01-07-announcing-layer_grouping-preview.md
+++ b/docs/blog/categories/preview/2026-01-07-announcing-layer_grouping-preview.md
@@ -7,7 +7,7 @@ parent: Preview
 grand_parent: Categories
 nav_exclude: false
 nav_order: -20260107
-categories: [Announcements, Preview]
+categories: [Preview]
 has_toc: true
 ---
 

--- a/docs/blog/categories/preview/2026-01-13-announcing-dynamic_layer_name-preview.md
+++ b/docs/blog/categories/preview/2026-01-13-announcing-dynamic_layer_name-preview.md
@@ -7,7 +7,7 @@ parent: Preview
 grand_parent: Categories
 nav_exclude: false
 nav_order: -20260113
-categories: [Announcements, Preview]
+categories: [Preview]
 has_toc: true
 ---
 

--- a/docs/blog/categories/preview/2026-03-25-announcing-overview_map-preview.md
+++ b/docs/blog/categories/preview/2026-03-25-announcing-overview_map-preview.md
@@ -7,7 +7,7 @@ parent: Preview
 grand_parent: Categories
 nav_exclude: false
 nav_order: -20260325
-categories: [Announcements, Preview]
+categories: [Preview]
 has_toc: true
 description: Real-time Progress and Precision Navigation at Your Fingertips.
 ---

--- a/docs/blog/categories/preview/2026-04-15-announcing-number_field_type-preview.md
+++ b/docs/blog/categories/preview/2026-04-15-announcing-number_field_type-preview.md
@@ -7,7 +7,7 @@ parent: Preview
 grand_parent: Categories
 nav_exclude: false
 nav_order: -20260415
-categories: [Announcements, Preview]
+categories: [Preview]
 has_toc: true
 description: Enhanced numeric input with decimal precision, min/max constraints, and scientific notation.
 ---

--- a/docs/blog/categories/preview/2026-06-26-announcing-element_variations-preview.md
+++ b/docs/blog/categories/preview/2026-06-26-announcing-element_variations-preview.md
@@ -7,7 +7,7 @@ parent: Preview
 grand_parent: Categories
 nav_exclude: false
 nav_order: -20260626
-categories: [Announcements, Preview]
+categories: [Preview]
 has_toc: true
 description: A Variations tab where each row captures one variation of a generic element.
 ---

--- a/docs/blog/categories/preview/2026-06-27-announcing-system_user_select-preview.md
+++ b/docs/blog/categories/preview/2026-06-27-announcing-system_user_select-preview.md
@@ -7,7 +7,7 @@ parent: Preview
 grand_parent: Categories
 nav_exclude: false
 nav_order: -20260627
-categories: [Announcements, Preview]
+categories: [Preview]
 has_toc: true
 description: Point a Select field at the host's real user directory instead of a fixed option list.
 ---

--- a/docs/blog/categories/preview/2026-06-28-announcing-formula_column-preview.md
+++ b/docs/blog/categories/preview/2026-06-28-announcing-formula_column-preview.md
@@ -7,7 +7,7 @@ parent: Preview
 grand_parent: Categories
 nav_exclude: false
 nav_order: -20260628
-categories: [Announcements, Preview]
+categories: [Preview]
 has_toc: true
 description: A read-only table column that calculates each row's value from the other columns.
 ---

--- a/docs/blog/categories/preview/2026-06-29-announcing-select_multi-preview.md
+++ b/docs/blog/categories/preview/2026-06-29-announcing-select_multi-preview.md
@@ -7,7 +7,7 @@ parent: Preview
 grand_parent: Categories
 nav_exclude: false
 nav_order: -20260629
-categories: [Announcements, Preview]
+categories: [Preview]
 has_toc: true
 description: Pick several options from a select list at once — in layer fields and table columns.
 ---

--- a/docs/blog/categories/preview/2026-06-30-announcing-ontology_select-preview.md
+++ b/docs/blog/categories/preview/2026-06-30-announcing-ontology_select-preview.md
@@ -7,7 +7,7 @@ parent: Preview
 grand_parent: Categories
 nav_exclude: false
 nav_order: -20260630
-categories: [Announcements, Preview]
+categories: [Preview]
 has_toc: true
 description: Pick a term from a controlled ontology tree instead of typing free text.
 ---

--- a/docs/blog/categories/preview/2026-07-13-announcing-mtt_assay-preview.md
+++ b/docs/blog/categories/preview/2026-07-13-announcing-mtt_assay-preview.md
@@ -7,7 +7,7 @@ parent: Preview
 grand_parent: Categories
 nav_exclude: false
 nav_order: -20260713
-categories: [Announcements, Preview]
+categories: [Preview]
 has_toc: true
 description: Turn wellplate readings into dose-response curves and endpoint (e.g. IC50) values, then attach the results back to your samples.
 ---

--- a/docs/blog/categories/preview/2026-07-14-announcing-reference-attribute-selection-preview.md
+++ b/docs/blog/categories/preview/2026-07-14-announcing-reference-attribute-selection-preview.md
@@ -7,7 +7,7 @@ parent: Preview
 grand_parent: Categories
 nav_exclude: false
 nav_order: -20260714
-categories: [Announcements, Preview]
+categories: [Preview]
 version: v2.4.0
 has_toc: true
 description: Pick which properties of a linked record show inline on a reference field — see the attributes you care about without opening the linked element.


### PR DESCRIPTION
## What

Removes `Announcements` from the `categories:` frontmatter of the 11 individual **feature** preview posts (`categories: [Announcements, Preview]` → `[Preview]`).

The 5 **Version X.Y.0 Public Preview** release posts keep `categories: [Announcements, Preview]`.

## Why

Individual feature previews were cluttering the Announcements category listing (`/blog/categories/announcements/`). Announcements should surface release milestones (the Public Preview posts), not every single feature preview.

## Notes

- One line changed per file; only the `categories:` array. Sidebar nav (`parent:`) is unaffected — these posts stay under **Preview**.
- Single commit, rebased onto current `main` — no conflicts.
- Supersedes the category portion of #42 (whose other commits — the Reference Attribute post, version badge, media centering — are already on `main` via squash-merge b54c8fe). #42 can be closed.